### PR TITLE
added routes for searching healthOfficials in database

### DIFF
--- a/server/records/routes.py
+++ b/server/records/routes.py
@@ -1,4 +1,5 @@
 import os
+import json
 import datetime
 from bson import ObjectId
 from server.config import Config
@@ -153,3 +154,18 @@ def addAttachment(_id, rid):
             break
     patient.save()
     return jsonify({"message": "Attachement Added!"}), 200
+
+
+@records.route("/api/users/search", defaults={"hid": None}, methods=["GET"])
+@records.route("/api/users/search/<hid>", methods=["GET"])
+@token_required
+def getHealthOfficials(_id, hid):
+    if hid is None:
+        healthOfficials = HealthOfficial.objects.scalar("name", "email").to_json()
+        return healthOfficials, 200
+    else:
+        healthOfficial = HealthOfficial.objects(_id=ObjectId(hid)).scalar(
+            "name", "email"
+        )
+        healthOfficial = healthOfficial.to_json()
+        return healthOfficial, 200


### PR DESCRIPTION
####  Endpoint ->  /api/users/search/hid
hid is an optional parameter in the endpoint url

#### Usage ->
hitting the url without hid returns response with details of all the healthOfficials in database.
hitting the url with hid returns response with details of the healthOfficial queried against hid
