### PR TITLE
updated and improved search api

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -9,8 +9,6 @@ class Config:
 
     MONGO_URI = os.getenv("MONGO_URI")
     SECRET_KEY = os.getenv("SECRET_KEY")
-    # MONGO_URI = "mongodb+srv://scooptroop:scooptroop123@elixir.csdhw.mongodb.net/elixir?retryWrites=true&w=majority"
-    # SECRET_KEY = "thiswillcontainsecretkey"
     ALLOWED_EXTENSIONS = {"txt", "pdf", "doc", "jpg", "jpeg", "png"}
     Path("server/static/uploads").mkdir(parents=True, exist_ok=True)
     UPLOAD_FOLDER = os.path.join(os.getcwd(), "server", "static", "uploads")


### PR DESCRIPTION
#### Endpoint => /api/users/search
#### Updates => expects params along with endpoint unlike previously when inURL args were required.
params -> **hid** & **name**
both the parameters are optional
suppling both the params simulataneously results in bad request(obviously)
#### Usage =>

1. /api/users/search
hitting the url without any params returns response with details of all the healthOfficials in the database.

2. /api/users/search?hid=<SAMPLE ID>
hitting the url with hid returns response with details of the healthOfficial queried against it.

3. /api/users/search?name=<SAMPLE NAME>
hitting the url with name returns response with details of all healthOfficials with similar names. (uses regex for string matching)

4. /api/users/search?hid=<SAMPLE ID>&name=<SAMPLE NAME>
bad request 400




