### PR TITLE
added feature enhancements: consultation requests

### DIFF
--- a/server/healthOfficial/routes.py
+++ b/server/healthOfficial/routes.py
@@ -1,7 +1,9 @@
+import re
+import json
 from bson import ObjectId
 from flask import request, jsonify, Blueprint
 from server.utils import token_required
-from server.models import Patient, HealthOfficial, Record, PatientNotifications
+from server.models import Patient, HealthOfficial, Record, ConsultationRequest
 from flask_cors import CORS
 
 healthOfficial = Blueprint("healthOfficial", __name__)
@@ -125,3 +127,52 @@ def addPatientRecord(_id, pid):
 
     except:
         return jsonify({"message": "Unable to create the record."}), 400
+
+
+@healthOfficial.route("/api/healthOfficial/consultations/get", methods=["GET"])
+@token_required
+def getRequests(_id):
+    req_id = request.args.get("req_id", default=None, type=str)
+    healthOfficial = HealthOfficial.objects(_id=ObjectId(_id)).first()
+    consultationRequests = healthOfficial.consultationRequests
+    # try:
+    if req_id is None:  # response with all requests
+        resp = []
+        for crequest in consultationRequests:
+            crequest = json.loads(crequest.to_json())
+            resp.append(crequest)
+        return jsonify(resp), 200
+
+    else:  # response with given req_id
+        for crequest in consultationRequests:
+            if crequest._id == ObjectId(req_id):
+                resp = json.loads(crequest.to_json())
+                return jsonify(resp), 200
+
+    # except:
+    return jsonify({"message": "Unexpected error occurred."}), 500
+
+
+@healthOfficial.route("/api/healthOfficial/consultations/delete", methods=["GET"])
+@token_required
+def deleteRequest(_id):
+    data = request.json
+    req_id = data["req_id"]
+    p_id = data["p_id"]
+    approved = request.args.get("approved", type=str)
+
+    healthOfficial = HealthOfficial.objects(_id=ObjectId(_id)).first()
+    crequests = []
+    for crequest in healthOfficial.consultationRequests:
+        if crequest._id == ObjectId(req_id):
+            pass
+        else:
+            crequests.append(crequest)
+
+    healthOfficial.consultationRequests = crequests
+
+    if approved == "True":
+        healthOfficial.patients.append(ObjectId(p_id))
+
+    healthOfficial.save()
+    return jsonify({"message": "Request executed successfully."})

--- a/server/models.py
+++ b/server/models.py
@@ -11,6 +11,7 @@ from mongoengine import (
     ObjectIdField,
     EmbeddedDocumentField,
 )
+from mongoengine.fields import EmbeddedDocumentListField
 
 
 class PatientNotifications(EmbeddedDocument):
@@ -71,7 +72,7 @@ class HealthOfficial(Document):
     email = EmailField(required=True, unique=True)
     password = StringField(required=True)
     patients = ListField(ObjectIdField())
-    consultationRequests = ListField(EmbeddedDocumentField(ConsultationRequest))
+    consultationRequests = EmbeddedDocumentListField(ConsultationRequest)
     records = StringField()
 
     meta = {"collection": "healthOfficial"}

--- a/server/records/routes.py
+++ b/server/records/routes.py
@@ -4,7 +4,14 @@ import datetime
 from bson import ObjectId
 from server.config import Config
 from server.utils import token_required, allowed_file
-from server.models import Patient, HealthOfficial, PatientNotifications, Record
+from server.models import (
+    ConsultationData,
+    ConsultationRequest,
+    Patient,
+    HealthOfficial,
+    PatientNotifications,
+    Record,
+)
 from flask_cors import CORS
 from flask import request, redirect, send_from_directory, abort, jsonify, Blueprint
 
@@ -90,7 +97,7 @@ def addRecord(_id):
             return jsonify({"message": "Record added successfully."}), 200
 
         except:
-            return jsonify({"message": "Unable to create the record."}), 400
+            return jsonify({"message": "Unable to create the record."}), 500
 
 
 @records.route("/api/users/records/<rid>", methods=["GET", "PUT"])
@@ -163,21 +170,59 @@ def getHealthOfficials(_id):
     name = request.args.get("name", default=None, type=str)
     regex = re.compile(f".*{name}.*", re.IGNORECASE)
 
-    if hid is None and name is None:
-        healthOfficials = HealthOfficial.objects.scalar("name", "email").to_json()
-        return healthOfficials, 200
+    try:
+        if hid is None and name is None:
+            healthOfficials = HealthOfficial.objects.scalar("name", "email").to_json()
+            return healthOfficials, 200
 
-    elif hid and name is None:
-        healthOfficial = HealthOfficial.objects(_id=ObjectId(hid)).scalar(
-            "name", "email"
-        )
-        healthOfficial = healthOfficial.to_json()
-        return healthOfficial, 200
+        elif hid and name is None:
+            healthOfficial = HealthOfficial.objects(_id=ObjectId(hid)).scalar(
+                "name", "email"
+            )
+            healthOfficial = healthOfficial.to_json()
+            return healthOfficial, 200
 
-    elif name and hid is None:
-        healthOfficial = HealthOfficial.objects(name=regex).scalar("name", "email")
-        healthOfficial = healthOfficial.to_json()
-        return healthOfficial, 200
+        elif name and hid is None:
+            healthOfficial = HealthOfficial.objects(name=regex).scalar("name", "email")
+            healthOfficial = healthOfficial.to_json()
+            return healthOfficial, 200
+
+        else:
+            return jsonify({"message": "Bad Request"}), 400
+
+    except:
+        return jsonify({"message": "Unexpected error occurred."}), 500
+
+
+@records.route("/api/users/consultations", methods=["POST"])
+@token_required
+def addConsultationRequest(_id):
+    if request.method == "POST":
+        try:
+            data = request.json
+            hid = data["hid"]
+            age = data["age"]
+            sex = data["sex"]
+            symptoms = data["symptoms"]
+            description = data["description"]
+
+            consultationData = ConsultationData(
+                age=age, sex=sex, symptoms=symptoms, description=description
+            )
+            consultationRequest = ConsultationRequest(
+                patient=ObjectId(_id),
+                healthOfficial=ObjectId(hid),
+                consultationData=consultationData,
+            )
+
+            healthOfficial = HealthOfficial.objects(_id=ObjectId(hid)).first()
+            healthOfficial.consultationRequests.append(consultationRequest)
+            healthOfficial.save()
+
+            return jsonify({"message": "Request sent successfully."}), 200
+
+        except:
+            return jsonify({"message": "Unexpected error occurred."}), 500
 
     else:
         return jsonify({"message": "Bad Request"}), 400


### PR DESCRIPTION
#### Feature enhancements corresponding to issue #23 for consultation requests
### New Endpoints:

#### 1. /api/users/consultations
Description:   
1. Accepted Methods = POST   
2. For patients to generate consultation request after searching for healthOfficials  

Usage:  
1. Expected fields in POST request json:
    a. hid -> string (healthOfficial ID)
    b. age -> int
    c. sex -> string
    d. symptoms -> List[string]
    e. description -> string

2. Response: 200 or 500



#### 2. /api/healthOfficial/consultations/get
Description:   
1. Accepted Methods = GET 
2. For healthOfficial to get single(in case of clickable link) or all the consultation requests received from different patients.

Usage:  
1. Optional params in GET request:
    a. req_id -> string (consultation request ID)

2. If req_id is supplied, responds with details of the single consultation request ELSE responds with a list of all the requests.

3. Response: ConsultationRequest JSON object or List of JSON objects    
4. NOTE: pls check models.py to know all the fields in response JSON object



#### 3. /api/healthOfficial/consultations/delete
Description:   
1. Accepted Methods = GET
2. For healthOfficial to approve or decline the consultation requests
3. request is deleted from db in both the cases, although if approved, the patient is added under healthOfficial.

Usage:  
1. Expected fields in GET request json:
    a. req_id -> string (request ID)
    b. p_id -> string (patient ID)

2. Expected params in GET request:
    a. approved -> string(True/False)

3. if approved is True, patient is added under healthOfficial. Consultation Request is deleted in both the cases.

4. Response 200 or 500




