### PR TITLE
Updated PatientNofifications Model and introduced new field of rtype

### DIFF
--- a/server/healthOfficial/routes.py
+++ b/server/healthOfficial/routes.py
@@ -3,7 +3,7 @@ import json
 from bson import ObjectId
 from flask import request, jsonify, Blueprint
 from server.utils import token_required
-from server.models import Patient, HealthOfficial, Record, ConsultationRequest
+from server.models import Patient, HealthOfficial, Record, PatientNotifications
 from flask_cors import CORS
 
 healthOfficial = Blueprint("healthOfficial", __name__)
@@ -169,9 +169,15 @@ def deleteRequest(_id):
             crequests.append(crequest)
 
     healthOfficial.consultationRequests = crequests
+    pnotif = PatientNotifications(healthOfficial=ObjectId(_id), rtype="consult")
 
     if approved == "True":
         healthOfficial.patients.append(ObjectId(p_id))
+        pnotif.approved = True
 
+    patient = Patient.objects(_id=ObjectId(p_id)).first()
+    patient.notifs.append(pnotif)
+
+    patient.save()
     healthOfficial.save()
     return jsonify({"message": "Request executed successfully."})

--- a/server/models.py
+++ b/server/models.py
@@ -19,6 +19,7 @@ class PatientNotifications(EmbeddedDocument):
     approved = BooleanField(default=False)
     healthOfficial = ObjectIdField()
     record = ObjectIdField()
+    rtype = StringField()
 
     meta = {"collection": "patientNotifications"}
 

--- a/server/notifications/routes.py
+++ b/server/notifications/routes.py
@@ -17,7 +17,7 @@ def getNotifications(_id):
 
         try:
             notif = PatientNotifications(
-                healthOfficial=ObjectId(_id), record=ObjectId(rid)
+                healthOfficial=ObjectId(_id), record=ObjectId(rid), rtype="consent"
             )
             patient = Patient.objects(_id=ObjectId(pid)).first()
             patient.notifs.append(notif)
@@ -37,6 +37,7 @@ def getNotifications(_id):
             notif_obj = dict()
             notif_obj["id"] = str(notif._id)
             notif_obj["approved"] = notif.approved
+            notif_obj["rtype"] = notif.rtype
 
             rid = notif.record
             record_obj = dict()


### PR DESCRIPTION
the updated model now can handle both types of notifications for patients, namely: consent and consultation requests.
associated updates are done in healthOfficial and notifications routes.

#### New Field in PatientNotifications Model : **rtype** -> string(consult / consent)